### PR TITLE
Remove getChanInfo RPC call

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -94,8 +94,6 @@ def getChannels():
                                 chan.node2_policy.fee_base_msat,
                                 chan.node2_policy.fee_rate_milli_msat,
                 )
-                s.add(channel)
-                s.commit()
             elif(chan.node2_pub == my_node_id):
                 channel = Channel(
                                 chan.chan_id,
@@ -108,8 +106,8 @@ def getChannels():
                                 chan.node1_policy.fee_base_msat,
                                 chan.node1_policy.fee_rate_milli_msat,
                 )
-                s.add(channel)
-                s.commit()
+            s.add(channel)
+            s.commit()
 
 
 

--- a/channel.py
+++ b/channel.py
@@ -72,7 +72,7 @@ def getChannels():
 
     request = ln.ListChannelsRequest()
     response = stub.ListChannels(request)
-    pubkeys = set([ sub['gfg'] for sub in test_list ])
+    pubkeys = list(set([ sub.remote_pubkey for sub in response.channels ]))
 
     for i in range(len(pubkeys)):
         
@@ -85,7 +85,7 @@ def getChannels():
         for chan in response2.channels:
             if(chan.node1_pub == my_node_id):
                 channel = Channel(
-                                chan.chan_id,
+                                chan.channel_id,
                                 chan.capacity,
                                 chan.node1_pub,
                                 chan.node1_policy.fee_base_msat,
@@ -99,7 +99,7 @@ def getChannels():
                 s.commit()
             elif(chan.node2_pub == my_node_id):
                 channel = Channel(
-                                chan.chan_id,
+                                chan.channel_id,
                                 chan.capacity,
                                 chan.node2_pub,
                                 chan.node2_policy.fee_base_msat,
@@ -111,8 +111,6 @@ def getChannels():
                 )
                 s.add(channel)
                 s.commit()
-            else:
-                # Channel not to my_node_id
 
 
 if __name__ == '__main__':

--- a/channel.py
+++ b/channel.py
@@ -72,12 +72,13 @@ def getChannels():
 
     request = ln.ListChannelsRequest()
     response = stub.ListChannels(request)
+    pubkeys = set([ sub['gfg'] for sub in test_list ])
 
-    for i in range(len(response.channels)):
+    for pubkey in range(len(pubkeys)):
         
         request2 = ln.NodeInfoRequest(
-            pub_key = response.channels[i].remote_pubkey,
-            include_channels = False,
+            pub_key = pubkey,
+            include_channels = True,
         )
         response2 = stub.GetNodeInfo(request2)
 

--- a/channel.py
+++ b/channel.py
@@ -81,37 +81,35 @@ def getChannels():
         )
         response2 = stub.GetNodeInfo(request2)
 
-        request3 = ln.ChanInfoRequest(
-            chan_id = response.channels[i].chan_id,
-        )
-        response3 = stub.GetChanInfo(request3)
-
-        if(response3.node1_pub == my_node_id):
-            channel = Channel(
-                            response.channels[i].chan_id,
-                            response.channels[i].capacity,
-                            response3.node1_pub,
-                            response3.node1_policy.fee_base_msat,
-                            response3.node1_policy.fee_rate_milli_msat,
-                            response3.node2_pub,
-                            response2.node.alias,
-                            response3.node2_policy.fee_base_msat,
-                            response3.node2_policy.fee_rate_milli_msat,
-            )
-        else:
-            channel = Channel(
-                            response.channels[i].chan_id,
-                            response.channels[i].capacity,
-                            response3.node2_pub,
-                            response3.node2_policy.fee_base_msat,
-                            response3.node2_policy.fee_rate_milli_msat,
-                            response3.node1_pub,
-                            response2.node.alias,
-                            response3.node1_policy.fee_base_msat,
-                            response3.node1_policy.fee_rate_milli_msat,
-            )
-        s.add(channel)
-        s.commit()
+        for chan in response2.channels:
+            if(chan.node1_pub == my_node_id):
+                channel = Channel(
+                                chan.chan_id,
+                                chan.capacity,
+                                chan.node1_pub,
+                                chan.node1_policy.fee_base_msat,
+                                chan.node1_policy.fee_rate_milli_msat,
+                                chan.node2_pub,
+                                response2.node.alias,
+                                chan.node2_policy.fee_base_msat,
+                                chan.node2_policy.fee_rate_milli_msat,
+                )
+                s.add(channel)
+                s.commit()
+            elif(chan.node2_pub == my_node_id):
+                channel = Channel(
+                                chan.chan_id,
+                                chan.capacity,
+                                chan.node2_pub,
+                                chan.node2_policy.fee_base_msat,
+                                chan.node2_policy.fee_rate_milli_msat,
+                                chan.node1_pub,
+                                response2.node.alias,
+                                chan.node1_policy.fee_base_msat,
+                                chan.node1_policy.fee_rate_milli_msat,
+                )
+                s.add(channel)
+                s.commit()
 
 
 

--- a/channel.py
+++ b/channel.py
@@ -94,6 +94,8 @@ def getChannels():
                                 chan.node2_policy.fee_base_msat,
                                 chan.node2_policy.fee_rate_milli_msat,
                 )
+                s.add(channel)
+                s.commit()
             elif(chan.node2_pub == my_node_id):
                 channel = Channel(
                                 chan.chan_id,
@@ -106,9 +108,10 @@ def getChannels():
                                 chan.node1_policy.fee_base_msat,
                                 chan.node1_policy.fee_rate_milli_msat,
                 )
-            s.add(channel)
-            s.commit()
-
+                s.add(channel)
+                s.commit()
+            else:
+                # Channel not to my_node_id
 
 
 if __name__ == '__main__':

--- a/channel.py
+++ b/channel.py
@@ -73,6 +73,7 @@ def getChannels():
     request = ln.ListChannelsRequest()
     response = stub.ListChannels(request)
     pubkeys = list(set([ sub.remote_pubkey for sub in response.channels ]))
+    channels = list(set([ sub.chan_id for sub in response.channels ]))
 
     for i in range(len(pubkeys)):
         
@@ -83,6 +84,8 @@ def getChannels():
         response2 = stub.GetNodeInfo(request2)
 
         for chan in response2.channels:
+            if (chan.channel_id not in channels):
+                continue
             if(chan.node1_pub == my_node_id):
                 channel = Channel(
                                 chan.channel_id,

--- a/channel.py
+++ b/channel.py
@@ -74,10 +74,10 @@ def getChannels():
     response = stub.ListChannels(request)
     pubkeys = set([ sub['gfg'] for sub in test_list ])
 
-    for pubkey in range(len(pubkeys)):
+    for i in range(len(pubkeys)):
         
         request2 = ln.NodeInfoRequest(
-            pub_key = pubkey,
+            pub_key = pubkeys[i],
             include_channels = True,
         )
         response2 = stub.GetNodeInfo(request2)


### PR DESCRIPTION
#2 のRPC実行時間の削減を目的としたプルリクです。

getChanInfoで取得していたRoutingPolicyはAlias取得のために叩いているgetNodeInfoのチャネルリストにすでに含まれているので、getNodeInfoに一本化することでRPCへの呼び出し回数をチャネル数のぶんだけ削減しました。
その代わり接続先ノードの全チャネルという大きなデータからmy_node_idへのチャネルをピックアップするので本当に実行時間の削減になるか検証が必要です。

実行時間の比較はおろか動作確認すらできていないので、マージ前にチェックしていただければ幸いです。(現在開発環境から離れておりGitHub web UIからのコミット)