### PR TITLE
added tzlocal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ Image
 sqlalchemy==1.3.6
 flask-cors
 apscheduler
+tzlocal<3.0 #apschdeuler==3.x requires tzlocal<3.0


### PR DESCRIPTION
現時点で apschdeuler をインストールするとバージョンが3.6.3となりますが、apschedulerの既知の問題でtzlocalのバージョン3.0以上だと不具合が生じるらしいのでとりあえず解決案として3.0未満(つまり2.1）をインストールするように設定します。